### PR TITLE
HDDS-4795. Separate source of Ozone container images to different repositories

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -12,16 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: build
-on:
-  - push
-  - pull_request
-jobs:
-  build:
-    name: build and deploy
-    runs-on: ubuntu-18.04
-    steps:
-      - name: checkout source
-        uses: actions/checkout@master
-      - name: build image
-        run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .
+github:
+  description: "Container image to provide build environment for developing and testing Apache Ozone"
+  homepage: https://ozone.apache.org
+  labels:
+    - ozone
+    - container
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false
+notifications:
+  commits:      commits@ozone.apache.org
+  issues:       issues@ozone.apache.org
+  pullrequests: issues@ozone.apache.org
+  jira_options: link label worklog

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## What changes were proposed in this pull request?
+
+(Please fill in changes proposed in this fix)
+
+## What is the link to the Apache JIRA
+
+(Please create an issue in ASF JIRA before opening a pull request,
+and you need to set the title of the pull request which starts with
+the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
+
+Please replace this section with the link to the Apache JIRA)
+
+## How was this patch tested?
+
+(Please explain how this patch was tested. Ex: unit tests, manual tests)
+(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: checkout source
         uses: actions/checkout@master
       - name: login with docker 
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.repository_owner }} --password-stdin ghcr.io
+        run: echo ${{ secrets.GHCR_CONTAINER_PUSH }} | docker login -u ${{ github.repository_owner }} --password-stdin ghcr.io
       - name: build image
         run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .
       - name: push image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: build
+jobs:
+  build:
+    name: build and deploy
+    runs-on: ubuntu-18.04
+    steps:
+      - name: checkout source
+        uses: actions/checkout@master
+      - name: login with docker 
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login -u ${{ github.repository_owner }} --password-stdin ghcr.io
+      - name: build image
+        run: docker build -t ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g') .
+      - name: push image
+        run: docker push ghcr.io/$(echo $GITHUB_REPOSITORY | sed 's/docker-//g')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: build
+on:
+  - push
 jobs:
   build:
     name: build and deploy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+# Contributing
+
+For detailed contribution guideline, please check the [contribution guideline of Apache Ozone repository](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y install gcc gcc-c++ kernel-devel make autoconf automake libtool which
    java-1.8.0-openjdk-headless java-1.8.0-openjdk-devel\
    docker \
    python-pip \ 
-   file python-devel \
+   file python3-devel \
    curl-devel dh-autoreconf expat-devel getopt gettext-devel openssl-devel perl-devel zlib-devel \
    jq \
    sudo
@@ -54,16 +54,16 @@ RUN mkdir -p /opt && \
 
 #Install apache-ant
 RUN mkdir -p /opt && \
-    curl -sL 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=/ant/binaries/apache-ant-1.10.7-bin.tar.gz' | tar -xz  && \
+    curl -sL 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=/ant/binaries/apache-ant-1.9.15-bin.tar.gz' | tar -xz  && \
        mv apache-ant* /opt/ant
 
 #Install apache-maven
-RUN curl -sL 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz' | tar -xz  && \
+RUN curl -sL 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz' | tar -xz  && \
         mv apache-maven* /opt/maven
 
 #Install docker-compose (for smoketests)
-RUN pip install --upgrade pip
-RUN pip install docker-compose
+RUN pip3 install --upgrade pip
+RUN pip3 install docker-compose
 
 ENV PATH=$PATH:/opt/findbugs/bin:/opt/maven/bin:/opt/ant/bin
 
@@ -80,7 +80,7 @@ RUN echo "ALL ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN ln -s /home/user/.m2 /root/.m2
 
 #blockade test
-RUN pip install virtualenv && virtualenv /opt/blockade && /opt/blockade/bin/pip install pytest==2.8.7 blockade
+RUN pip3 install virtualenv && virtualenv /opt/blockade && /opt/blockade/bin/pip3 install pytest==2.8.7 blockade
 ENV PATH=$PATH:/opt/blockade/bin
 
 #kubectl
@@ -88,7 +88,7 @@ RUN cd /usr/local/bin && \
    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
    chmod +x ./kubectl
 
-RUN pip install robotframework
+RUN pip3 install robotframework
 
 RUN curl -sL https://github.com/muquit/mailsend-go/releases/download/v1.0.5/mailsend-go_1.0.5_linux-64bit.tar.gz | tar zxf - && mv mailsend-go-dir/mailsend-go /usr/local/bin/ && rm -rf mailsend-go-dir
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,7 @@
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Apache Ozone, Build Environment
 
-# Apache Hadoop Ozone Build Environment
+This repository contains the definition of a helper container for building [Apache Ozone](https://ozone.apache.org)
 
-This image contains all the required tool to build and test Apache Hadoop Ozone projects.
+Container contains all the required dependencies (and some cached artifacts).
 
-
-
+Used by some of the [Github Actions](https://github.com/apache/ozone/tree/master/.github/workflows) of the main repository.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,48 @@
-# Apache Ozone, Build Environment
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Apache Ozone **build** environment
 
 This repository contains the definition of a helper container for building [Apache Ozone](https://ozone.apache.org)
 
 Container contains all the required dependencies (and some cached artifacts).
 
-Used by some of the [Github Actions](https://github.com/apache/ozone/tree/master/.github/workflows) of the main repository.
+Used by some of the [Github Actions](https://github.com/apache/ozone/tree/master/.github/workflows) of the main Ozone repository.
+
+The image is available as [apache/ozone-build](https://hub.docker.com/r/apache/ozone-build). Build is managed by Docker Hub.
+
+## Development
+
+To build the image, please use:
+
+```
+docker build -t apache/ozone-build:dev .
+```
+
+To test it, you can test any build step inside the container:
+
+```
+docker -it -v `pwd`:/opt/ozone` bash
+cd /opt/ozone
+mvn clean install -DskipTests
+```
+
+Note: the image assumes that the Ozone source tree (`pwd` in our example) is writted by the user with id=1000.
+
+
+*After merging PR, a new tag can be pushed to the repository to create a new image. Use the convention: `YYYYMMDD-N` for tags where N is a daily counter (see the existing tags as an example).
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 # Security Policy
 
-This container image (`apache/ozone-runner`) is indented to be used only in *test and dev* environment. Please don't use it in production environment.
+This container image (`apache/ozone-build`) is indented to be used only in *test and dev* environment. Please don't use it in production environment.
 
 The process of reporting Apache Ozone vulnerabilities [defined in the main Apache Ozone repository](https://github.com/apache/ozone/blob/master/SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+This container image (`apache/ozone-runner`) is indented to be used only in *test and dev* environment. Please don't use it in production environment.
+
+The process of reporting Apache Ozone vulnerabilities [defined in the main Apache Ozone repository](https://github.com/apache/ozone/blob/master/SECURITY.md).


### PR DESCRIPTION
Similar to apache/ozone-docke-runnerr #fd796d64ce6e387ad7b93e88605ed97cc755ef85, this pull request contains initial README/builds/github actions after the separation.